### PR TITLE
refactor[authentication]: reworks the token verification using JWKS url

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,24 +30,22 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	// Get provider configuration
-	provider, err := auth.GetOIDCProvider(providerEndpoint)
+	provider, err := auth.GetProviderInfo(providerEndpoint)
 	if err != nil {
 		log.Fatalf("Failed to retrieve provider configuration: %v\n", err)
 	}
 
-	// get token endpint from the provider
-	tokenUrl := provider.Endpoint().TokenURL
-
 	// Retrieve an OIDC token using the password grant type
-	accessToken, err := auth.RequestJWT(username, password, otp, tokenUrl, c.ClientID, c.ClientSecret, c.ClientScope)
+	accessToken, err := auth.RequestJWT(username, password, otp, provider.TokenURL, c.ClientID, c.ClientSecret, c.ClientScope)
 	if err != nil {
 		log.Fatalf("Failed to retrieve token: %v\n", err)
 		os.Exit(2)
 	}
 
 	// Verify the token and retrieve the ID token
-	if err := auth.VerifyToken(accessToken, c.ClientID, c.ClientSecret, c.Realm, c.Endpoint); err != nil {
+	if err := provider.VerifyToken(accessToken); err != nil {
 		// handle the error
 		log.Fatal(err)
 		os.Exit(3)


### PR DESCRIPTION
# Description

This branch makes the requirement of a confidential client optional. This is to reduce attack surface by removing secrets from multiple install locations and simplify deployment to many resources by not requiring secrets to be deployed.

**Note:** This removes the token introspection code which makes a call to the identity provider to validated the token. Instead, this code relies on the local decoding and validation of the token. There is notably an omission of validation of `aud` (audience) on the tokens. Validating audience can be added in if desired, but it is commonly optional and would optimally leverage a configuration flag.

Fixes `no issue allocated`

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
  - Rational: This is the addition of keycloak public client usage
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - Rational: The only notable "breaking" change here is that the token validation doesn't rely on a call out to the keycloak server and instead does token validation locally.
- [ ] This change requires a documentation update
  - Rational: Please just let me know if this is something you'd like documented in terms of usage. It is just the omission of the client secret and a different flow when describing the client creation.

# How Has This Been Tested?

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

This code was tested (prior to the latest merge from master) on live systems for login in a testing event. For more info, see [this commit](https://github.com/sradigan/kc-ssh-pam/commit/46d6b12ffdca01e058262a1b432aee2c9b664e6c). I cherry picked the changes against the updated master and re-wrote the commit message to be in-line with the contributions guide.

> No tests exist in the repo right now, so no additional testing was written for this
> - [ ] Running existing tests 
> - [ ] Created new tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`
