### PR TITLE
fix[authentication]: update a typo for scope in the authentication request

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -76,7 +76,7 @@ func RequestJWT(username, password, otp, tokenUrl, clientid, clientsecret, clien
 	urlV.Add("password", password)
 
 	if len(clientscope) > 0 {
-		urlV.Add("scop", clientscope)
+		urlV.Add("scope", clientscope)
 	}
 
 	if len(otp) > 0 {


### PR DESCRIPTION
Updated the spelling of scope for the authentication request.

# Description

There is a typo in the `auth.go` file that leads to malformed requests with a specified client scope. This PR resolves the issue by updating the spelling of the request key.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Running existing tests

This was tested by running a series of requests in Postman to ensure the original spelling was incorrect, and then the library was recompiled to ensure the typo was resolved.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have rebased my branch to include the latest changes from `master`
